### PR TITLE
FIX : Handle errors better for /api/1.0/datapoints when given invalid parameters #6

### DIFF
--- a/app/api_1_0/datapoint.py
+++ b/app/api_1_0/datapoint.py
@@ -8,12 +8,6 @@ from flask import request
 import predix.data.timeseries
 
 from . import api, query_string_to_dictionary
-
-# Let's patch the URL Lib mode to handle the Pythn2to3 Migration
-from future.standard_library import install_aliases
-install_aliases()
-
-from urllib.parse import urlparse
  
 timeseries = predix.data.timeseries.TimeSeries()
 

--- a/app/api_1_0/datapoint.py
+++ b/app/api_1_0/datapoint.py
@@ -8,7 +8,7 @@ from flask import request
 import predix.data.timeseries
 
 from . import api, query_string_to_dictionary
- 
+
 timeseries = predix.data.timeseries.TimeSeries()
 
 @api.route('/datapoints')
@@ -42,21 +42,21 @@ def datapoints():
 
         [
             {
-                "GP_CO2": 32.035, 
+                "GP_CO2": 32.035,
                 "x": 1471421209000
-            }, 
+            },
             {
-                "GP_CO2": 32.035, 
+                "GP_CO2": 32.035,
                 "x": 1471423009000
-            }, 
+            },
             {
-                "GP_CO2": 32.035, 
+                "GP_CO2": 32.035,
                 "x": 1471424807000
-            }, 
+            },
             {
-                "GP_CO2": 32.035, 
+                "GP_CO2": 32.035,
                 "x": 1471426606000
-            }, 
+            },
             ...
         ]
 
@@ -107,7 +107,7 @@ def datapoints():
 def _validate_node_and_sensor(node_value, sensor_values):
     data = dict()
     with open(
-            os.path.expanduser("~/.predix/volcano.json")) as volcano_cache:
+        os.path.expanduser("~/.predix/volcano.json")) as volcano_cache:
         data = json.loads(volcano_cache)
 
     node_match = [

--- a/app/dashboard/views.py
+++ b/app/dashboard/views.py
@@ -1,6 +1,7 @@
-
+import os
 import re
 import json
+import errno
 from flask import render_template
 
 import predix.data.asset
@@ -42,8 +43,25 @@ def home():
             "val": sensor['data_type'] + " (%s)" % (sensor['tag'])
             })
 
+    _cache_nodes_and_sensors(nodes, sensors)
     # Render the dashboard jinja2 template
     return render_template('home.html',
             sensors=json.dumps(natural_sort(sensors)),
             default_node=default_node,
             nodes=json.dumps(natural_sort(nodes)))
+
+
+def _cache_nodes_and_sensors(nodes, sensors):
+    cache_path = os.path.expanduser("~/.predix")
+    if not os.path.exists(cache_path):
+        try:
+            os.makedirs(cache_path)
+        except OSError as exc:
+            if exc.errno != errno.EEXIST:
+                raise
+    data = {
+        "sensors": sensors,
+        "nodes": nodes
+    }
+    with open("~/.predix/volcano.json", "w") as volcano_cache:
+        volcano_cache.write(json.dumps(data))

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ python-dateutil>=2.6.0
 PyYAML>=3.12
 sphinx_rtd_theme
 sphinxcontrib-httpdomain
+future==0.15.2


### PR DESCRIPTION
Invalid and Empty Node/Sensor Data will return `HTTP 402` with `[]` response body.